### PR TITLE
feat: assign Resource Policy Contributor Role by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Azure Resource Manager (ARM) template that configures OpenID Connect (OIDC) auth
 
 - Creates a managed identity with the given name in Azure.
 - Adds federated credentials for the GitHub OIDC identity provider with the given names and subjects.
-- Assigns the given roles at the subscription scope (`Contributor` and `Role Based Access Control Administrator` by default).
+- Assigns the given roles at the subscription scope (`Contributor`, `Role Based Access Control Administrator` and `Resource Policy Contributor` by default).
 - Creates a read-only lock to prevent changes to the managed identity.
 
 ## Prerequisites
@@ -66,7 +66,7 @@ Azure Resource Manager (ARM) template that configures OpenID Connect (OIDC) auth
 | `resourceGroupName` | The name of the resource group to create. | `string` | |
 | `managedIdentityName` | The name of the managed identity to create. | `string` | |
 | `federatedCredentials` | An array of federated credentials to add to the managed identity. | `{ "name": string, "subject": string }[]` | `[]` |
-| `roleAssignments` | An array of role assignments to create at the subscription scope. | `{ "roleDefinitionId": string, "condition": string? }[]` | <details><summary>Show default</summary>`[{ "roleDefinitionId": "b24988ac-6180-42a0-ab88-20f7382dd24c" }, { "roleDefinitionId": "f58310d9-a9f6-439a-9e8d-f62e7b41a168", "condition": "((!(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {8e3af657-a8ff-443c-a75c-2fe8c4bcb635, 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9, f58310d9-a9f6-439a-9e8d-f62e7b41a168})) AND ((!(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {8e3af657-a8ff-443c-a75c-2fe8c4bcb635, 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9, f58310d9-a9f6-439a-9e8d-f62e7b41a168}))" }]`</details> |
+| `roleAssignments` | An array of role assignments to create at the subscription scope. | `{ "roleDefinitionId": string, "condition": string? }[]` | <details><summary>Show default</summary>`[{ "roleDefinitionId": "b24988ac-6180-42a0-ab88-20f7382dd24c" }, { "roleDefinitionId": "f58310d9-a9f6-439a-9e8d-f62e7b41a168", "condition": "((!(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {8e3af657-a8ff-443c-a75c-2fe8c4bcb635, 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9, f58310d9-a9f6-439a-9e8d-f62e7b41a168})) AND ((!(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {8e3af657-a8ff-443c-a75c-2fe8c4bcb635, 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9, f58310d9-a9f6-439a-9e8d-f62e7b41a168}))" }, { "roleDefinitionId": "36243c78-bf99-498c-9df9-86d9f8d28608" }]`</details> |
 
 > [!TIP]
 > Rather than passing parameters as inline values, create a [parameter file](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/parameter-files).

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "17665709958384110733"
+      "templateHash": "7422466315318726100"
     }
   },
   "definitions": {
@@ -69,6 +69,9 @@
         {
           "roleDefinitionId": "f58310d9-a9f6-439a-9e8d-f62e7b41a168",
           "condition": "((!(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {8e3af657-a8ff-443c-a75c-2fe8c4bcb635, 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9, f58310d9-a9f6-439a-9e8d-f62e7b41a168})) AND ((!(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {8e3af657-a8ff-443c-a75c-2fe8c4bcb635, 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9, f58310d9-a9f6-439a-9e8d-f62e7b41a168}))"
+        },
+        {
+          "roleDefinitionId": "36243c78-bf99-498c-9df9-86d9f8d28608"
         }
       ],
       "metadata": {

--- a/main.bicep
+++ b/main.bicep
@@ -28,6 +28,9 @@ param roleAssignments roleAssignmentType[] = [
     roleDefinitionId: 'f58310d9-a9f6-439a-9e8d-f62e7b41a168' // Role Based Access Control Administrator, with condition to prevent privilege escalation
     condition: '''((!(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {8e3af657-a8ff-443c-a75c-2fe8c4bcb635, 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9, f58310d9-a9f6-439a-9e8d-f62e7b41a168})) AND ((!(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {8e3af657-a8ff-443c-a75c-2fe8c4bcb635, 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9, f58310d9-a9f6-439a-9e8d-f62e7b41a168}))'''
   }
+  {
+    roleDefinitionId: '36243c78-bf99-498c-9df9-86d9f8d28608' // Resource Policy Contributor 
+  }
 ]
 
 param managedIdentityDeploymentName string = 'managedIdentity-${utcNow()}'


### PR DESCRIPTION
Allow service principal to create and manage policy definitions, policy assignments, policy exemptions and policy sets, allowing the service principal to manage subscription governance.
